### PR TITLE
Clamp progress to 1 in Note.stop().

### DIFF
--- a/src/Note.js
+++ b/src/Note.js
@@ -22,7 +22,7 @@ class Note extends Tone{
 		if (this.output.buffer){
 
 			// return the amplitude of the damper playback
-			let progress = (time - this._startTime) / this.output.buffer.duration
+			let progress = Math.min(1, (time - this._startTime) / this.output.buffer.duration)
 			progress = (1 - progress) * this._velocity
 			// stop the buffer
 			this.output.stop(time, 0.2)


### PR DESCRIPTION
So that there is no error even when called after a time that exceeds duration.

This fixes an error I was getting occasionally: `ERROR TypeError: Failed to set the 'value' property on 'AudioParam': The provided float value is non-finite.`