### PR TITLE
Fix ESM exports paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,41 @@ Tone Piano is a Web Audio instrument which uses high-quality multi-sampled piano
 
 It has up to 16 velocity levels across 88 keys (sampled every third note) of a Yamaha C5. 
 
+## Install
+
+Install the npm package:
+
+```
+npm install --save @tonejs/piano
+```
+
+Tone Piano requires Tone.js as a peer dependency (and webmidi to use MidiKeyboard):
+
+```
+npm install --save tone
+# optional
+npm install --save webmidi
+```
+
+
 ## Usage
 
-Tone Piano requires Tone.js as a peer dependency. 
+### Import
+
+Using CommonJS:
+
+```js
+const Piano = require('@tonejs/piano');
+```
+
+Using ES6 modules:
+
+```js
+import { Piano } from '@tonejs/piano'
+```
+
+### Create and load samples
+
 
 ```javascript
 // create the piano and load 5 velocity steps
@@ -27,6 +59,8 @@ piano.load().then(() => {
 	console.log('loaded!')
 })
 ```
+
+## API reference
 
 Once the samples are loaded, it exposes 4 methods for playing the notes:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonejs/piano",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,68 +1,68 @@
 {
-  "name": "@tonejs/piano",
-  "version": "0.1.2",
-  "description": "Web Audio instrument using Salamander Grand Piano samples",
-  "repository": {
-    "url": "https://github.com/tambien/Piano"
-  },
-  "main": "build/Piano.js",
-  "module": "build/esm/Piano.js",
-  "types": "build/esm/Piano.d.ts",
-  "scripts": {
-    "help": "node scripts/help.js",
-    "help:verbose": "node scripts/help.js -v",
-    "build": "rm -rf ./build && npm run webpack:build && npm run tsc:build",
-    "prepare": "npm run build",
-    "tsc:build": "tsc -p tsconfig.json -d true",
-    "tsc:watch": "tsc -p tsconfig.json --watch",
-    "webpack:build": "webpack -p --mode=production",
-    "webpack:watch": "webpack -w --mode=development",
-    "build:debug": "webpack --debug",
-    "build:watch:debug": "webpack -w --debug",
-    "compileAndBuild": "node scripts/compileAndBuild.js",
-    "compileAndBuild:watch": "npm-run-all -p compile:watch build:watch",
-    "compileAndBuild:debug": "npm run compileAndBuild -- -d",
-    "compileAndBuild:watch:debug": "npm-run-all -p compile:watch build:watch:debug",
-    "increment": "npm version v$(semver --increment $(npm show @tonejs/piano version)) --git-tag-version=false --allow-same-version",
-    "lint": "tslint --project tsconfig.json --fix",
-    "test": "npm run webpack:build && npm run test:mocha",
-    "test:debug": "npm run compileAndBuild:debug && npm run test:mocha:debug",
-    "test:mocha": "mocha test/test.js --timeout 30000",
-    "test:mocha:debug": "npm run test:mocha -- --dbg --timeout 0"
-  },
-  "files": [
-    "README.md",
-    "LICENSE",
-    "build",
-    "src",
-    "scripts"
-  ],
-  "author": "Yotam Mann",
-  "license": "MIT",
-  "devDependencies": {
-    "@types/node": "^12.6.2",
-    "chai": "^4.1.2",
-    "mocha": "^5.2.0",
-    "npm-run-all": "^4.1.5",
-    "puppeteer": "^1.19.0",
-    "semver": "^5.5.0",
-    "static-server": "^2.2.1",
-    "tone": "^14.3.32",
-    "ts-loader": "^6.0.4",
-    "tslint": "^5.18.0",
-    "typescript": "^3.5.3",
-    "webmidi": "^2.3.3",
-    "webpack": "^4.40.2",
-    "webpack-cli": "^3.3.9"
-  },
-  "peerDependencies": {
-    "tone": "^14.1.18",
-    "webmidi": "^2.3.3"
-  },
-  "keywords": [
-    "Web Audio",
-    "Tone.js",
-    "Piano",
-    "Sampler"
-  ]
+	"name": "@tonejs/piano",
+	"version": "0.1.1",
+	"description": "Web Audio instrument using Salamander Grand Piano samples",
+	"repository": {
+	  "url": "https://github.com/tambien/Piano"
+	},
+	"main": "build/Piano.js",
+	"module": "build/esm/Piano.js",
+	"types": "build/esm/Piano.d.ts",
+	"scripts": {
+		"help": "node scripts/help.js",
+		"help:verbose": "node scripts/help.js -v",
+		"build": "rm -rf ./build && npm run webpack:build && npm run tsc:build",
+		"prepare": "npm run build",
+		"tsc:build": "tsc -p tsconfig.json -d true",
+		"tsc:watch": "tsc -p tsconfig.json --watch",
+		"webpack:build": "webpack -p --mode=production",
+		"webpack:watch": "webpack -w --mode=development",
+		"build:debug": "webpack --debug",
+		"build:watch:debug": "webpack -w --debug",
+		"compileAndBuild": "node scripts/compileAndBuild.js",
+		"compileAndBuild:watch": "npm-run-all -p compile:watch build:watch",
+		"compileAndBuild:debug": "npm run compileAndBuild -- -d",
+		"compileAndBuild:watch:debug": "npm-run-all -p compile:watch build:watch:debug",
+		"increment": "npm version v$(semver --increment $(npm show @tonejs/piano version)) --git-tag-version=false --allow-same-version",
+		"lint": "tslint --project tsconfig.json --fix",
+		"test": "npm run webpack:build && npm run test:mocha",
+		"test:debug": "npm run compileAndBuild:debug && npm run test:mocha:debug",
+		"test:mocha": "mocha test/test.js --timeout 30000",
+		"test:mocha:debug": "npm run test:mocha -- --dbg --timeout 0"
+	},
+	"files": [
+		"README.md",
+		"LICENSE",
+		"build",
+		"src",
+		"scripts"
+	],
+	"author": "Yotam Mann",
+	"license": "MIT",
+	"devDependencies": {
+		"@types/node": "^12.6.2",
+		"chai": "^4.1.2",
+		"mocha": "^5.2.0",
+		"npm-run-all": "^4.1.5",
+		"puppeteer": "^1.19.0",
+		"semver": "^5.5.0",
+		"static-server": "^2.2.1",
+		"tone": "^14.3.32",
+		"ts-loader": "^6.0.4",
+		"tslint": "^5.18.0",
+		"typescript": "^3.5.3",
+		"webmidi": "^2.3.3",
+		"webpack": "^4.40.2",
+		"webpack-cli": "^3.3.9"
+	},
+	"peerDependencies": {
+		"tone": "^14.1.18",
+		"webmidi": "^2.3.3"
+	},
+	"keywords": [
+		"Web Audio",
+		"Tone.js",
+		"Piano",
+		"Sampler"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -1,65 +1,68 @@
 {
-	"name": "@tonejs/piano",
-	"version": "0.1.1",
-	"description": "Web Audio instrument using Salamander Grand Piano samples",
-	"main": "build/Piano.js",
-	"module": "build/esm/index.js",
-	"types": "build/esm/index.d.ts",
-	"scripts": {
-		"help": "node scripts/help.js",
-		"help:verbose": "node scripts/help.js -v",
-		"build": "rm -rf ./build && npm run webpack:build && npm run tsc:build",
-		"prepare": "npm run build",
-		"tsc:build": "tsc -p tsconfig.json",
-		"tsc:watch": "tsc -p tsconfig.json --watch",
-		"webpack:build": "webpack -p --mode=production",
-		"webpack:watch": "webpack -w --mode=development",
-		"build:debug": "webpack --debug",
-		"build:watch:debug": "webpack -w --debug",
-		"compileAndBuild": "node scripts/compileAndBuild.js",
-		"compileAndBuild:watch": "npm-run-all -p compile:watch build:watch",
-		"compileAndBuild:debug": "npm run compileAndBuild -- -d",
-		"compileAndBuild:watch:debug": "npm-run-all -p compile:watch build:watch:debug",
-		"increment": "npm version v$(semver --increment $(npm show @tonejs/piano version)) --git-tag-version=false --allow-same-version",
-		"lint": "tslint --project tsconfig.json --fix",
-		"test": "npm run webpack:build && npm run test:mocha",
-		"test:debug": "npm run compileAndBuild:debug && npm run test:mocha:debug",
-		"test:mocha": "mocha test/test.js --timeout 30000",
-		"test:mocha:debug": "npm run test:mocha -- --dbg --timeout 0"
-	},
-	"files": [
-		"README.md",
-		"LICENSE",
-		"build",
-		"src",
-		"scripts"
-	],
-	"author": "Yotam Mann",
-	"license": "MIT",
-	"devDependencies": {
-		"@types/node": "^12.6.2",
-		"chai": "^4.1.2",
-		"mocha": "^5.2.0",
-		"npm-run-all": "^4.1.5",
-		"puppeteer": "^1.19.0",
-		"semver": "^5.5.0",
-		"static-server": "^2.2.1",
-		"tone": "^14.3.32",
-		"ts-loader": "^6.0.4",
-		"tslint": "^5.18.0",
-		"typescript": "^3.5.3",
-		"webmidi": "^2.3.3",
-		"webpack": "^4.40.2",
-		"webpack-cli": "^3.3.9"
-	},
-	"peerDependencies": {
-		"tone": "^14.1.18",
-		"webmidi": "^2.3.3"
-	},
-	"keywords": [
-		"Web Audio",
-		"Tone.js",
-		"Piano",
-		"Sampler"
-	]
+  "name": "@tonejs/piano",
+  "version": "0.1.2",
+  "description": "Web Audio instrument using Salamander Grand Piano samples",
+  "repository": {
+    "url": "https://github.com/tambien/Piano"
+  },
+  "main": "build/Piano.js",
+  "module": "build/esm/Piano.js",
+  "types": "build/esm/Piano.d.ts",
+  "scripts": {
+    "help": "node scripts/help.js",
+    "help:verbose": "node scripts/help.js -v",
+    "build": "rm -rf ./build && npm run webpack:build && npm run tsc:build",
+    "prepare": "npm run build",
+    "tsc:build": "tsc -p tsconfig.json -d true",
+    "tsc:watch": "tsc -p tsconfig.json --watch",
+    "webpack:build": "webpack -p --mode=production",
+    "webpack:watch": "webpack -w --mode=development",
+    "build:debug": "webpack --debug",
+    "build:watch:debug": "webpack -w --debug",
+    "compileAndBuild": "node scripts/compileAndBuild.js",
+    "compileAndBuild:watch": "npm-run-all -p compile:watch build:watch",
+    "compileAndBuild:debug": "npm run compileAndBuild -- -d",
+    "compileAndBuild:watch:debug": "npm-run-all -p compile:watch build:watch:debug",
+    "increment": "npm version v$(semver --increment $(npm show @tonejs/piano version)) --git-tag-version=false --allow-same-version",
+    "lint": "tslint --project tsconfig.json --fix",
+    "test": "npm run webpack:build && npm run test:mocha",
+    "test:debug": "npm run compileAndBuild:debug && npm run test:mocha:debug",
+    "test:mocha": "mocha test/test.js --timeout 30000",
+    "test:mocha:debug": "npm run test:mocha -- --dbg --timeout 0"
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "build",
+    "src",
+    "scripts"
+  ],
+  "author": "Yotam Mann",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^12.6.2",
+    "chai": "^4.1.2",
+    "mocha": "^5.2.0",
+    "npm-run-all": "^4.1.5",
+    "puppeteer": "^1.19.0",
+    "semver": "^5.5.0",
+    "static-server": "^2.2.1",
+    "tone": "^14.3.32",
+    "ts-loader": "^6.0.4",
+    "tslint": "^5.18.0",
+    "typescript": "^3.5.3",
+    "webmidi": "^2.3.3",
+    "webpack": "^4.40.2",
+    "webpack-cli": "^3.3.9"
+  },
+  "peerDependencies": {
+    "tone": "^14.1.18",
+    "webmidi": "^2.3.3"
+  },
+  "keywords": [
+    "Web Audio",
+    "Tone.js",
+    "Piano",
+    "Sampler"
+  ]
 }


### PR DESCRIPTION
Currently, the library is not usable with ES6 modules since package.json fields points to non-existing files.

Also type definitions are not generated, so it doesn't work with Typescript.

Both issues are resolved in this PR and the README is updated.

`package.json` **before this PR**:
```js
  "module": "build/esm/index.js", // <- this file doesn't exist
  "types": "build/esm/index.d.js", // <- this file is not generated at all by tsc
```

`package.json` **after this PR**:
```js
  "module": "build/esm/Piano.js",
  "types": "build/esm/Piano.d.ts",
```

Thanks for all your awesome work! 🎉 