### PR TITLE
Add `"type": "module"` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"main": "build/esm/Piano.js",
 	"module": "build/esm/Piano.js",
 	"type": "module",
+	"unpkg": "build/Piano.js",
 	"types": "build/esm/Piano.d.ts",
 	"scripts": {
 		"build": "tsc",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	},
 	"main": "build/Piano.js",
 	"module": "build/esm/Piano.js",
+	"type": "module",
 	"types": "build/esm/Piano.d.ts",
 	"scripts": {
 		"build": "tsc",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"repository": {
 	  "url": "https://github.com/tambien/Piano"
 	},
-	"main": "build/Piano.js",
+	"browser": "build/Piano.js",
 	"module": "build/esm/Piano.js",
 	"type": "module",
 	"types": "build/esm/Piano.d.ts",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	  "url": "https://github.com/tambien/Piano"
 	},
 	"browser": "build/Piano.js",
+	"main": "build/esm/Piano.js",
 	"module": "build/esm/Piano.js",
 	"type": "module",
 	"types": "build/esm/Piano.d.ts",


### PR DESCRIPTION
This change was merged into the main Piano.js library: https://github.com/Tonejs/Tone.js/pull/908 & https://github.com/Tonejs/Tone.js/pull/914