### PR TITLE
Pedal should not be considered up at the exact moment when it goes down

### DIFF
--- a/src/piano/Pedal.ts
+++ b/src/piano/Pedal.ts
@@ -72,6 +72,6 @@ export class Pedal extends PianoComponent {
 	 * Indicates if the pedal is down at the given time
 	 */
 	isDown(time: number): boolean {
-		return time > this._downTime
+		return time >= this._downTime
 	}
 }


### PR DESCRIPTION
We're using this in an app that plays MIDI files in sync with an interactive piano roll visualization. Overall it's working incredibly well, but we've encountered one scenario in which the app and the Piano can get into an inconsistent state: if a `Piano.pedalDown()` is followed immediately by a `Piano.pedalUp()` on the same timestamp, the false `isDown()` check causes the `Piano.pedalUp()` to terminate without changing the pedal state. The app thus assumes that the pedal is up when in fact the Piano still has it in the "down" state.

We could sidestep this scenario by rewriting our app to avoid overlapping pedal events, or by artificially incrementing the `time` parameter between them. But the proposed change below is the simplest, and moreover, in our view it makes the Piano's behavior a bit more logically consistent. At least, we can't see any case in which it's beneficial to consider the pedal not to be down at the very moment at which it has moved to the "down" state.
